### PR TITLE
Few cleanups to tf

### DIFF
--- a/opentofu/main.tf
+++ b/opentofu/main.tf
@@ -65,7 +65,7 @@ module "graphdb" {
   allowed_ingress_cidrs = ["10.0.0.0/8", "192.168.0.0/16", "35.191.0.0/16"]
 }
 
-module "geoconex_features_pygeoapi" {
+module "geoconnex_features_pygeoapi" {
   source = "./pygeoapi"
   region = var.region
   config_bucket      = module.storage.s3_bucket

--- a/opentofu/main.tf
+++ b/opentofu/main.tf
@@ -65,8 +65,8 @@ module "graphdb" {
   allowed_ingress_cidrs = ["10.0.0.0/8", "192.168.0.0/16", "35.191.0.0/16"]
 }
 
-module "pygeoapi" {
-  source = "./pygeoapi"
+module "geoconex_features_pygeoapi" {
+  source = "./geoconex_features_pygeoapi"
   region = var.region
   config_bucket      = module.storage.s3_bucket
   POSTGRES_PASSWORD = var.database_password

--- a/opentofu/main.tf
+++ b/opentofu/main.tf
@@ -66,7 +66,7 @@ module "graphdb" {
 }
 
 module "geoconex_features_pygeoapi" {
-  source = "./geoconex_features_pygeoapi"
+  source = "./pygeoapi"
   region = var.region
   config_bucket      = module.storage.s3_bucket
   POSTGRES_PASSWORD = var.database_password

--- a/opentofu/main.tf
+++ b/opentofu/main.tf
@@ -65,7 +65,7 @@ module "graphdb" {
   allowed_ingress_cidrs = ["10.0.0.0/8", "192.168.0.0/16", "35.191.0.0/16"]
 }
 
-module "geoconnex_features_pygeoapi" {
+module "pygeoapi" {
   source = "./pygeoapi"
   region = var.region
   config_bucket      = module.storage.s3_bucket

--- a/opentofu/pygeoapi/main.tf
+++ b/opentofu/pygeoapi/main.tf
@@ -1,4 +1,4 @@
-resource "google_cloud_run_v2_service" "geoconex_features_pygeoapi" {
+resource "google_cloud_run_v2_service" "pygeoapi" {
   name                = "geoconex_features_pygeoapi"
   location            = var.region
   deletion_protection = false

--- a/opentofu/pygeoapi/main.tf
+++ b/opentofu/pygeoapi/main.tf
@@ -1,5 +1,5 @@
 resource "google_cloud_run_v2_service" "pygeoapi" {
-  name                = "pygeoapi"
+  name                = "geoconnex-features-pygeoapi"
   location            = var.region
   deletion_protection = false
 

--- a/opentofu/pygeoapi/main.tf
+++ b/opentofu/pygeoapi/main.tf
@@ -1,5 +1,5 @@
 resource "google_cloud_run_v2_service" "pygeoapi" {
-  name                = "geoconex_features_pygeoapi"
+  name                = "pygeoapi"
   location            = var.region
   deletion_protection = false
 

--- a/opentofu/pygeoapi/main.tf
+++ b/opentofu/pygeoapi/main.tf
@@ -1,5 +1,5 @@
-resource "google_cloud_run_v2_service" "pygeoapi" {
-  name                = "pygeoapi"
+resource "google_cloud_run_v2_service" "geoconex_features_pygeoapi" {
+  name                = "geoconex_features_pygeoapi"
   location            = var.region
   deletion_protection = false
 

--- a/opentofu/pygeoapi/pygeoapi.config.yml
+++ b/opentofu/pygeoapi/pygeoapi.config.yml
@@ -70,12 +70,16 @@ resources:
         rel: canonical
         title: Geoconnex registry
         href: https://github.com/internetofwater/geoconnex.us
+      - type: application/html
+        rel: documentation
+        title: Geoconnex documentation
+        href: https://docs.geoconnex.us/
     keywords:
       en:
         - geoconnex
     extents:
       spatial:
-        bbox: [-114.816591,31.332177,-109.045172,37.003725]
+        bbox: [-179.231086, 18.865460, -66.885444, 71.538800]
         crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
       temporal:
         begin: 1902-03-31T00:00:00Z 


### PR DESCRIPTION
- rename generic `pygeoapi` service to `geoconnex_features_pygeoapi`. (Could be something else if preferred as well, just want to avoid using a generic `pygeoapi` name since it will show up in the gcp console without extra info just that generic name)
- change the spatial extent for geoconnex to the entire us, not just arizona. This was a relic from copying over the asu awo config for pygeoapi