### PR TITLE
Dont build images on every prod deploy

### DIFF
--- a/opentofu/instances/main.tf
+++ b/opentofu/instances/main.tf
@@ -101,7 +101,6 @@ resource "google_compute_instance" "harvest_vm" {
 
     echo "Pulling Scheduler images" >> /var/log/startup.log
     make pull
-    make prodBuild
 
     # Step 4: Run Scheduler
     nohup make cloudProd


### PR DESCRIPTION
Ideally this should just spin up the prebuilt images that were specified in https://github.com/internetofwater/scheduler/pull/239