### PR TITLE
Change Harvest Machine Type

### DIFF
--- a/opentofu/instances/main.tf
+++ b/opentofu/instances/main.tf
@@ -2,6 +2,7 @@ resource "google_compute_instance" "harvest_vm" {
   name         = var.name
   machine_type = var.machine_type
   zone         = var.zone
+  allow_stopping_for_update = true
   metadata     = {
     enable-osconfig = "TRUE"
   }
@@ -11,6 +12,7 @@ resource "google_compute_instance" "harvest_vm" {
     initialize_params {
       image = "debian-cloud/${var.instance_os}"
       size  = var.disk_size
+      type  = "pd-ssd"
     }
   }
 

--- a/opentofu/instances/qlever.tf
+++ b/opentofu/instances/qlever.tf
@@ -11,7 +11,7 @@ resource "google_compute_instance" "qlever_vm" {
   boot_disk {
     initialize_params {
       image = "debian-cloud/${var.instance_os}"
-      size  = var.disk_size
+      size  = var.qlever_disk_size
       type  = "pd-ssd"
     }
   }

--- a/opentofu/instances/qlever.tf
+++ b/opentofu/instances/qlever.tf
@@ -2,6 +2,7 @@ resource "google_compute_instance" "qlever_vm" {
   name         = "${var.name}-qlever-vm"
   machine_type = var.qlever_machine_type
   zone         = var.zone
+  allow_stopping_for_update = true
   metadata     = {
     enable-osconfig = "TRUE"
   }
@@ -14,7 +15,6 @@ resource "google_compute_instance" "qlever_vm" {
       type  = "pd-ssd"
     }
   }
-
   network_interface {
     network = var.network_name
     access_config {
@@ -77,8 +77,9 @@ resource "google_compute_instance" "qlever_vm" {
     # gcsfuse --only-dir geoconnex_index ${var.s3_bucket} /data
 
     # Step 7: Start Qlever
-    
-    sudo -u qlever qlever-server -i /data/geoconnex -j 16 -p 8888 -s 300s
+
+    cd /data
+    qlever-server -i geoconnex -j 16 -p 8888 -s 300s
 
   EOF
 }

--- a/opentofu/instances/variables.tf
+++ b/opentofu/instances/variables.tf
@@ -30,13 +30,13 @@ variable "enable_public_url" {
 variable "machine_type" {
   description = "Machine type for GCP instances (overrides instance_type in production)"
   type        = string
-  default     = "e2-highcpu-16"
+  default     = "e2-highmem-8"
 }
 
 variable "qlever_machine_type" {
   description = "Machine type for GCP instances (overrides instance_type in production)"
   type        = string
-  default     = "e2-highcpu-16"
+  default     = "e2-highmem-8"
 }
 
 variable "zone" {

--- a/opentofu/instances/variables.tf
+++ b/opentofu/instances/variables.tf
@@ -11,6 +11,12 @@ variable "instance_os" {
 variable "disk_size" {
   description = "Boot disk size for each VM instance (in GB)"
   type        = number
+  default     = 128
+}
+
+variable "qlever_disk_size" {
+  description = "Boot disk size for each VM instance (in GB)"
+  type        = number
   default     = 80
 }
 


### PR DESCRIPTION
Update harvest machine type and machine ssd to ensure we have enough memory to create the index and run the crawl.
- Separate out the configuration of machine type and the disk storage for qlever and harvest vm
- Change harvest vm to ssd disk
- 